### PR TITLE
Consolidate similar methods

### DIFF
--- a/source/Refactorings/RefactoringSettings.cs
+++ b/source/Refactorings/RefactoringSettings.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Josef Pihrt. All rights reserved. Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+
 namespace Pihrtsoft.CodeAnalysis.CSharp.Refactorings
 {
     public sealed class RefactoringSettings
@@ -18,50 +20,9 @@ namespace Pihrtsoft.CodeAnalysis.CSharp.Refactorings
             return !_disabledRefactorings.Contains(identifier);
         }
 
-        public bool IsAnyRefactoringEnabled(string identifier, string identifier2)
+        public bool IsAnyRefactoringEnabled(params string[] identifiers)
         {
-            return IsRefactoringEnabled(identifier)
-                || IsRefactoringEnabled(identifier2);
-        }
-
-        public bool IsAnyRefactoringEnabled(string identifier, string identifier2, string identifier3)
-        {
-            return IsRefactoringEnabled(identifier)
-                || IsRefactoringEnabled(identifier2)
-                || IsRefactoringEnabled(identifier3);
-        }
-
-        public bool IsAnyRefactoringEnabled(string identifier, string identifier2, string identifier3, string identifier4)
-        {
-            return IsRefactoringEnabled(identifier)
-                || IsRefactoringEnabled(identifier2)
-                || IsRefactoringEnabled(identifier3)
-                || IsRefactoringEnabled(identifier4);
-        }
-
-        public bool IsAnyRefactoringEnabled(string identifier, string identifier2, string identifier3, string identifier4, string identifier5)
-        {
-            return IsRefactoringEnabled(identifier)
-                || IsRefactoringEnabled(identifier2)
-                || IsRefactoringEnabled(identifier3)
-                || IsRefactoringEnabled(identifier4)
-                || IsRefactoringEnabled(identifier5);
-        }
-
-        public bool IsAnyRefactoringEnabled(
-            string identifier,
-            string identifier2,
-            string identifier3,
-            string identifier4,
-            string identifier5,
-            string identifier6)
-        {
-            return IsRefactoringEnabled(identifier)
-                || IsRefactoringEnabled(identifier2)
-                || IsRefactoringEnabled(identifier3)
-                || IsRefactoringEnabled(identifier4)
-                || IsRefactoringEnabled(identifier5)
-                || IsRefactoringEnabled(identifier6);
+            return identifiers.Any(IsRefactoringEnabled);
         }
 
         public void SetIsRefactoringEnabled(string identifier, bool isEnabled)


### PR DESCRIPTION
Take advantage of the params keyword to get rid of the several similar methods.
Depending on your preference of style you might also like to merge `IsRefactoringEnabled` and `IsAnyRefactoringEnabled`.